### PR TITLE
Add NGX_FREEBSD support.

### DIFF
--- a/ngx_x_rid_header_module.c
+++ b/ngx_x_rid_header_module.c
@@ -26,16 +26,23 @@ ngx_int_t ngx_x_rid_header_get_variable(ngx_http_request_t *r, ngx_http_variable
   }       
       
 #if (NGX_FREEBSD)
+  char *p_tmp;
   uuid_t uuid;
   uint32_t uuid_status;
   uuid_create(&uuid, &uuid_status);
   if ( uuid_status != uuid_s_ok ) {
     return -1;
   }
-  uuid_to_string(&uuid, (char **)&p, &uuid_status);
+  uuid_to_string(&uuid, (char **)&p_tmp, &uuid_status);
   if ( uuid_status != uuid_s_ok ) {
     return -1;
   }
+
+  if ( memmove(p, p_tmp, 36) < 0 ) {
+    free(p_tmp);
+    return -1;
+  }
+  free(p_tmp);
 #elif (NGX_LINUX)
   uuid_t* uuid;
   if ( uuid_create(&uuid) ) {

--- a/ngx_x_rid_header_module.c
+++ b/ngx_x_rid_header_module.c
@@ -38,7 +38,7 @@ ngx_int_t ngx_x_rid_header_get_variable(ngx_http_request_t *r, ngx_http_variable
     return -1;
   }
 
-  if ( memmove(p, p_tmp, 36) < 0 ) {
+  if ( memmove(p, p_tmp, 37) < 0 ) {
     free(p_tmp);
     return -1;
   }

--- a/ngx_x_rid_header_module.c
+++ b/ngx_x_rid_header_module.c
@@ -4,7 +4,7 @@
 #include <ngx_http_variables.h>
 
 #if (NGX_FREEBSD)
-#error FreeBSD is not supported yet, sorry.
+#include <uuid.h>
 #elif (NGX_LINUX)
 #include <uuid.h>      
 #elif (NGX_SOLARIS)
@@ -26,7 +26,16 @@ ngx_int_t ngx_x_rid_header_get_variable(ngx_http_request_t *r, ngx_http_variable
   }       
       
 #if (NGX_FREEBSD)
-#error FreeBSD is not supported yet, sorry.
+  uuid_t uuid;
+  uint32_t uuid_status;
+  uuid_create(&uuid, &uuid_status);
+  if ( uuid_status != uuid_s_ok ) {
+    return -1;
+  }
+  uuid_to_string(&uuid, (char **)&p, &uuid_status);
+  if ( uuid_status != uuid_s_ok ) {
+    return -1;
+  }
 #elif (NGX_LINUX)
   uuid_t* uuid;
   if ( uuid_create(&uuid) ) {


### PR DESCRIPTION
Uses the FreeBSD uuid(3) functions. Correctly compiles for me, though I've not yet tested it in a running nginx instance.
